### PR TITLE
Set up a cookiecutter repo as a basic project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,120 @@
 # example-project
-Guide for best practices during the dlmbl project phase
+
+[Cookiecutter](https://github.com/cookiecutter/cookiecutter) and [cruft](https://cruft.github.io/cruft/) are tools that make it easy to generate projects from reusable templates. This repo serves as a template for your project and offers some advice on best practices for deep learning and data science projects.
+
+## Git for version control
+
+[^1]: Adapted from [The Essentials of Git for Budding Data Scientists](https://www.dasca.org/world-of-data-science/article/the-essentials-of-git-for-budding-data-scientists)
+
+Git is a version control system that allows you to easily track changes in you code while also facilitating collaboration on code-based projects. Git maintains a central repository ("origin" or "remote") while individual users work off a copy that they clone to their local machine ("local" or clone"). When users have made they want so share they save the changes with a "commit" and "push" the changes back to the remote.
+
+### Basic Terminology
+
+Repository
+: Your project folder with versioned files and their history
+
+Branch
+: Each branch Different lines of development that can be used to facilitate independent development and then later merged back together
+
+Commit
+: A snapshot of your project's history with a message describing the version
+
+Clone
+: A local copy of a repository
+
+Pull
+: Retrieve changes from the remote and merge them into the local clone
+
+Push
+: Share changes from the local clone to the remote
+
+Merge
+: Combine changes from two branches
+
+Checkout
+: Switch to a different branch or a previous commit
+
+Fetch
+: Download changes from the remote without applying them to the local clone
+
+### Basic git workflow
+
+![git workflow](https://storage.googleapis.com/noble-mimi/noble_ebooks/front-end-tools-and-portfolio-edition1.0-1/img/git-overall-workflow-diagram.png)
+
+When you are working on a project versioned with git you will always follow the same basic routine.
+
+1. Run `git pull` to check if there are any changes to the remote that need to be applied to your local clone
+2. Make changes to your code
+3. When you are ready to save your changes, run `git status` to check with files have changed
+4. In order to tell git to track the changes, they need to be "staged". Run `git add path/to/file` to stage your changes for inclusion in the next commit
+5. Run `git commit -m "<your commit message>"` to save your staged changes. Write a short message describing the changes you made in this commit.
+6. `git push` to share the new commit with the remote repository
+
+When you are working in a group, each group member will usually develop code on their own branch. When a feature is complete, the branch can be merged into the `main` branch to share the changes with the rest of the group. To create a new branch run `git checkout -b <branch-name>`. Your branch name can describe the feature you are working on and include your username to identify the branch. For example, `username/metrics` or `username/dataloader`.
+
+### What files can you track with git
+
+Git is intended to be used to track relatively small text files. You should never add data or models to your git repository! Most repositories will include a `.gitignore` file with includes a list of file patterns that git should exclude from tracking, such as `*.zarr`, `*.tiff`, etc.
+
+## Specifying your environment
+
+In order to ensure that your group members (and future you) can run your code, we will specify the set of python packages that are required for your code to run. It's also a good idea to make a note of what python version you are working with and cruft will prompt you to pick a python version when you are creating your project.
+
+The requirements for your code are specified in the `pyproject.toml` file in the dependencies section, which will look something like this:
+```toml
+dependencies = [
+    "torch",
+    "ipykernel",
+    # Other packages that are needed to run your code
+]
+```
+Commonly you will end up adding packages for visualization (`matplotlib` or `napari`) and data loading (`zarr`). Generally if you find yourself installing a package on the fly, remember to add it to your dependencies section.
+
+## Writing and installing your code
+
+During the project phase, we will collect any reusable code into a python module. You can find the first essential file in your module at `{{ project name }}/src/__init__.py`. We'll discuss when to add code into a module later, but in the meantime we need to install our module so that the code can be imported from anywhere.
+
+From your project environment, you will run `pip install -e .`. The `-e` flag tells pip to install the package in editable mode which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
+
+## The role of notebooks
+
+Notebooks are a great place to experiment, explore data and initially develop new code. In order to stay organized and keep track of your progress, we suggest treating each notebook like an entry in a lab notebook. Consider including the date in the name of the notebook and starting your notebook with a markdown cell that describes what you are working on in that notebook. Future you will thank past you when you are looking back through your notebooks and trying to figure out what you were thinking and working on.
+
+As you are saving your model and other outputs, we suggest putting a timestamp in your filenames so that you don't accidentally overwrite the output of a previous experiment.
+```python
+import datetime
+
+# Generate a time stamp with YYYYMMDD-HHMMSS
+tstamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+model_path = f'ModelName-{tstamp}'
+```
+
+### When should code become src code
+
+If you find yourself copying and pasting the same code from one notebook to another, it's time to move your code into a python module so that you can import it wherever you need it. In the  `src/project_name` folder, create a new file for your code. If your code is not already in a standalone function, rewrite it as a function and save it into your new file.
+
+---
+
+## Getting started on your project
+
+### Connecting to Github through VSCode
+
+For the purposes of this course, we recommend connecting to Github through the VSCode extension Github Pull Requests. After connecting to your remote machine through VSCode, you can install the Github Pull Requests extension from the marketplace. After it is installed, open the Github Pull Requests extension from the sidebar and select the "Sign In" button in order to authenticate VSCode to use your Github account.
+
+### Creating the project repo
+
+Only one person needs to do these initial steps
+1. Connect to your remote machine using the VSCode ssh extension.
+2. Create your project repo using cruft. It will prompt you for series of values that it will use to complete the template.
+```bash
+pip install cruft
+cruft create https://github.com/dlmbl/example-project
+```
+3. Open the source control extension and select "Publish to Github" button.
+
+You are now ready to invite your group members to collaborate on your github repository for the project. Follow these [github instructions](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository#inviting-a-collaborator-to-a-personal-repository) to add your group members to the project repo.
+
+### Cloning your project repo
+
+If you did not directly set up the project repo, you will need to clone it onto your remote machine. You can use the button with the option "Clone Repository" to look up your project repo once you have been added as a collaborator.

--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ dependencies = [
 ```
 Commonly you will end up adding packages for visualization (`matplotlib` or `napari`) and data loading (`zarr`). Generally if you find yourself installing a package on the fly, remember to add it to your dependencies section.
 
-## Writing and installing your code
-
-During the project phase, we will collect any reusable code into a python module. You can find the first essential file in your module at `{{ project name }}/src/__init__.py`. We'll discuss when to add code into a module later, but in the meantime we need to install our module so that the code can be imported from anywhere.
-
-From your project environment, you will run `pip install -e .`. The ` -e` flag tells pip to install the package in editable mode which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
-
 ## The role of notebooks
 
 Notebooks are a great place to experiment, explore data and initially develop new code. In order to stay organized and keep track of your progress, we suggest treating each notebook like an entry in a lab notebook. Consider including the date in the name of the notebook and starting your notebook with a markdown cell that describes what you are working on in that notebook. Future you will thank past you when you are looking back through your notebooks and trying to figure out what you were thinking and working on.
@@ -93,7 +87,7 @@ model_path = f'ModelName-{tstamp}'
 
 ### When should code become src code
 
-If you find yourself copying and pasting the same code from one notebook to another, it's time to move your code into a python module so that you can import it wherever you need it. In the  `src/project_name` folder, create a new file for your code. If your code is not already in a standalone function, rewrite it as a function and save it into your new file.
+If you find yourself copying and pasting the same code from one notebook to another, it's time to move your code into a python module so that you can import it wherever you need it. You can find the first essential file in your module at `{{ project name }}/src/__init__.py`. The `__init__.py` is actually what makes something an installable python module. To add code to the module, in the  `src/project_name` folder, create a new file for your code. If your code is not already in a standalone function, rewrite it as a function and save it into your new file.
 
 ---
 
@@ -119,3 +113,12 @@ You are now ready to invite your group members to collaborate on your github rep
 ### Cloning your project repo
 
 If you did not directly set up the project repo, you will need to clone it onto your remote machine. You can use the button with the option "Clone Repository" to look up your project repo once you have been added as a collaborator.
+
+### Installing your repo
+
+During the project phase, we will collect any reusable code into a python module. To import the resuable code from the module, you will need to install the module into your evironment. 
+
+First you will need to make a conda environment for your project and activate it. Then, from the folder containing your repository, run `pip install -e .`. The ` -e` flag tells pip to install the package in editable mode, which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
+
+Now, you can import your functions using `from <package_name>.<file_name> import <function_name>`
+at the top of your scripts and other files in the module. Any changes to the function will be automatically updated in the environment, and in notebooks if the autoreload extension is active.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you find yourself copying and pasting the same code from one notebook to anot
 
 ### Connecting to Github through VSCode
 
-For the purposes of this course, we recommend connecting to Github through the VSCode extension Github Pull Requests. After connecting to your remote machine through VSCode, you can install the Github Pull Requests extension from the marketplace. After it is installed, open the Github Pull Requests extension from the sidebar and select the "Sign In" button in order to authenticate VSCode to use your Github account.
+For the purposes of this course, we recommend connecting to Github through the VSCode extension Github Pull Requests. After connecting to your remote machine through VSCode, you can install the Github Pull Requests extension from the marketplace. After it is installed, open the Github Pull Requests extension from the sidebar and select the "Sign In" button in order to authenticate VSCode to use your Github account. Once we are signed in to Github through the Github Pull Requests extension, we will just use the Source tab in VSCode.
 
 ### Creating the project repo
 
@@ -116,7 +116,7 @@ If you did not directly set up the project repo, you will need to clone it onto 
 
 ### Installing your repo
 
-During the project phase, we will collect any reusable code into a python module. To import the resuable code from the module, you will need to install the module into your evironment. 
+During the project phase, we will collect any reusable code into a python module. To import the resuable code from the module, you will need to install the module into your evironment.
 
 First you will need to make a conda environment for your project and activate it. Then, from the folder containing your repository, run `pip install -e .`. The ` -e` flag tells pip to install the package in editable mode, which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ If you find yourself copying and pasting the same code from one notebook to anot
 
 For the purposes of this course, we recommend connecting to Github through the VSCode extension Github Pull Requests. After connecting to your remote machine through VSCode, you can install the Github Pull Requests extension from the marketplace. After it is installed, open the Github Pull Requests extension from the sidebar and select the "Sign In" button in order to authenticate VSCode to use your Github account. Once we are signed in to Github through the Github Pull Requests extension, we will just use the Source tab in VSCode.
 
+We need to do one last configuration step before we are ready to use git from VSCode. Open a terminal in VSCode and run the following commands substituting in your information as needed.
+```bash
+git config --global user.email "your-email@email.com"
+git config --global user.name "Your Name"
+```
+
 ### Creating the project repo
 
 Only one person needs to do these initial steps

--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@
 
 [^1]: Adapted from [The Essentials of Git for Budding Data Scientists](https://www.dasca.org/world-of-data-science/article/the-essentials-of-git-for-budding-data-scientists)
 
-Git is a version control system that allows you to easily track changes in you code while also facilitating collaboration on code-based projects. Git maintains a central repository ("origin" or "remote") while individual users work off a copy that they clone to their local machine ("local" or clone"). When users have made they want so share they save the changes with a "commit" and "push" the changes back to the remote.
+Git is a version control system that allows you to easily track changes in you code while also facilitating collaboration on code-based projects. Git maintains a central repository ("origin" or "remote") while individual users work off a copy that they clone to their local machine ("local" or clone"). When users want to share changes they have made locally, they save the changes with a "commit" and "push" the changes back to the remote.
 
 ### Basic Terminology
 
 Repository
 : Your project folder with versioned files and their history
 
-Branch
-: Each branch Different lines of development that can be used to facilitate independent development and then later merged back together
-
 Commit
-: A snapshot of your project's history with a message describing the version
+: A single point in the Git repository history; the entire history of a repository is represented as a set of interrelated commits. Commits in git are defined relative to other commits,
+so each commit represents a set of changes from the previous version.
+
+Branch
+: A line of development, consisting of a series of commits. There is a "main" branch holding the stable code. Developers can create new branches when adding new features to avoid messing up the main branch until they are done testing, or to avoid conflicting with other developers. When ready, branches are "merged" back into main.
 
 Clone
 : A local copy of a repository
@@ -58,7 +59,7 @@ Git is intended to be used to track relatively small text files. You should neve
 
 ## Specifying your environment
 
-In order to ensure that your group members (and future you) can run your code, we will specify the set of python packages that are required for your code to run. It's also a good idea to make a note of what python version you are working with and cruft will prompt you to pick a python version when you are creating your project.
+In order to ensure that your group members (and future you) can run your code, we will specify the set of python packages that are required for your code to run. It's also a good idea to make a note of what python version you are working with and cruft will prompt you to pick a python version when you are creating your project. We recommend choosing python 3.10 or greater, unless you need to use an older version for one of your dependencies.
 
 The requirements for your code are specified in the `pyproject.toml` file in the dependencies section, which will look something like this:
 ```toml
@@ -74,7 +75,7 @@ Commonly you will end up adding packages for visualization (`matplotlib` or `nap
 
 During the project phase, we will collect any reusable code into a python module. You can find the first essential file in your module at `{{ project name }}/src/__init__.py`. We'll discuss when to add code into a module later, but in the meantime we need to install our module so that the code can be imported from anywhere.
 
-From your project environment, you will run `pip install -e .`. The `-e` flag tells pip to install the package in editable mode which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
+From your project environment, you will run `pip install -e .`. The ` -e` flag tells pip to install the package in editable mode which means that any changes you make to the code will be reflected in your environment. The `.` tells pip where to look (the current directory) for the `pyproject.toml` file which contains the configuration of your package including the dependencies that you have specified.
 
 ## The role of notebooks
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Cookiecutter](https://github.com/cookiecutter/cookiecutter) and [cruft](https://cruft.github.io/cruft/) are tools that make it easy to generate projects from reusable templates. This repo serves as a template for your project and offers some advice on best practices for deep learning and data science projects.
 
-## Git for version control
+## Git for version control[^1]
 
 [^1]: Adapted from [The Essentials of Git for Budding Data Scientists](https://www.dasca.org/world-of-data-science/article/the-essentials-of-git-for-budding-data-scientists)
 
@@ -51,11 +51,24 @@ When you are working on a project versioned with git you will always follow the 
 5. Run `git commit -m "<your commit message>"` to save your staged changes. Write a short message describing the changes you made in this commit.
 6. `git push` to share the new commit with the remote repository
 
+### Commit messages
+
+Your commit messages serve as a record of your changes and though process behind them. Future you always benefits from good commit messages! Read more [here](https://cbea.ms/git-commit/) about how to write good commit messages.
+
+### Branching
+
 When you are working in a group, each group member will usually develop code on their own branch. When a feature is complete, the branch can be merged into the `main` branch to share the changes with the rest of the group. To create a new branch run `git checkout -b <branch-name>`. Your branch name can describe the feature you are working on and include your username to identify the branch. For example, `username/metrics` or `username/dataloader`.
 
 ### What files can you track with git
 
 Git is intended to be used to track relatively small text files. You should never add data or models to your git repository! Most repositories will include a `.gitignore` file with includes a list of file patterns that git should exclude from tracking, such as `*.zarr`, `*.tiff`, etc.
+
+### Learn more about git
+
+Your TAs are happy to answer questions about and help resolve problems with git during the course. You can learn more about git on your own through the following resources:
+
+- [Learn Git Branching](https://learngitbranching.js.org/): An interactive visual website that teaches you how to use git.
+- [`git gud`](https://github.com/benthayer/git-gud): An interactive CLI tool that features a progression of levels that teach you git skills.
 
 ## Specifying your environment
 
@@ -71,7 +84,25 @@ dependencies = [
 ```
 Commonly you will end up adding packages for visualization (`matplotlib` or `napari`) and data loading (`zarr`). Generally if you find yourself installing a package on the fly, remember to add it to your dependencies section.
 
-## The role of notebooks
+## Organizing your code
+
+### Common terminology[^2]
+
+[^2]: Adapted from https://realpython.com/lessons/scripts-modules-packages-and-libraries/
+
+Script
+: A Python file that’s intended to be run directly. They often contain code written outside the scope of classes or functions and might import modules, packages and libraries.
+
+Module
+: A Python file that’s intended to be imported into scripts or other modules. It often defines classes, functions, and variables intended to be used in other files that import it.
+
+Package
+: A collection of related modules that work together to provide certain functionality. These modules are contained within a folder and can be imported just like any other modules. This folder will often contain a special `__init__` file that tells Python it’s a package, potentially containing more modules nested within subfolders.
+
+Library
+: An umbrella term that loosely means “a bundle of code.” These can have tens or even hundreds of individual modules that can provide a wide range of functionality.
+
+### The role of notebooks
 
 Notebooks are a great place to experiment, explore data and initially develop new code. In order to stay organized and keep track of your progress, we suggest treating each notebook like an entry in a lab notebook. Consider including the date in the name of the notebook and starting your notebook with a markdown cell that describes what you are working on in that notebook. Future you will thank past you when you are looking back through your notebooks and trying to figure out what you were thinking and working on.
 
@@ -128,3 +159,9 @@ First you will need to make a conda environment for your project and activate it
 
 Now, you can import your functions using `from <package_name>.<file_name> import <function_name>`
 at the top of your scripts and other files in the module. Any changes to the function will be automatically updated in the environment, and in notebooks if the autoreload extension is active.
+
+---
+
+# Additional Resources
+
+[Cookiecutter for Data Science](https://cookiecutter-data-science.drivendata.org/): This is a more elaborate cookiecutter repo that is set up for a data science project. There are components that you don't need for your DL@MBL projects, but this is a great resource for features you might want to include in the future.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,0 +1,8 @@
+{
+    "full_name": "Funke Lab",
+    "email": "funkej@hhmi.org",
+    "project_name": "dlmbl project",
+    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+    "project_short_description": "package description.",
+    "default_python": "3.10"
+}

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
-    "full_name": "Funke Lab",
-    "email": "funkej@hhmi.org",
+    "full_name": "Your Name",
+    "email": "yourname@gmail.com",
     "project_name": "dlmbl project",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "project_short_description": "package description.",

--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -1,0 +1,124 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Pdoc documentation
+docs/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+pyrepo
+.vscode/
+
+# OS Files
+.DS_Store

--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -1,3 +1,8 @@
+# data files
+*.zarr
+*.tiff
+*.tif
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,0 +1,10 @@
+# {{ cookiecutter.project_name }}
+
+## Getting Started
+
+Create a new environment
+```bash
+conda create -n {{ cookiecutter.project_slug }} python={{ cookiecutter.default_python }}
+conda activate {{ cookiecutter.default_python }}
+pip install -e .
+```

--- a/{{ cookiecutter.project_slug }}/notebooks/README.md
+++ b/{{ cookiecutter.project_slug }}/notebooks/README.md
@@ -1,0 +1,3 @@
+# README
+
+Collect your project notebooks here!

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel"]
+
+[project]
+name = "{{ cookiecutter.project_name }}"
+description = "{{ cookiecutter.project_short_description }}"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+  "Programming Language :: Python :: 3",
+]
+keywords = []
+license = { text = "BSD 3-Clause License" }
+authors = [
+    { email = "{{ cookiecutter.email}} ", name = "{{ cookiecutter.full_name}} " },
+]
+dynamic = ["version"]
+dependencies = [
+    # Add your requirements here
+]


### PR DESCRIPTION
This exercise is trying to serve two purposes: 1) use cookiecutter to offer a basic template for how students should set up their projects, 2) explain general best practices including using git, writing source code, defining an environment and appropriate use of notebooks.

I am currently envisioning that the first part of the exercise will be more of a lecture covering the material in `README`. Then we'll go into a more hands on session setting up github access through VSCode. Then I'm considering having them do a brief demo by initializing a repo locally and going through the basic commit workflow. I'm also considering having them deliberately create branches with merge conflicts and then go through the process of resolving the conflict. TBD as to whether this is helpful or too complicated. 

I'm very open to adding any type of additional content to this repo if there are other things that you remember coming up during projects that I have left out. 